### PR TITLE
Migrate repo to use new release workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,12 +13,9 @@ parameters:
   docker-engine-version:
     type: string
     default: 20.10.7
-  cimg-base-version:
+  go-version:
     type: string
-    default: 2021.11-20.04
-  goreleaser-version:
-    type: string
-    default: "v1.9.2"
+    default: "1.17"
   # The dirpath where kudet dist subdirectories are found, relative to the workspace root
   kudet-dist-home-relative-dirpath:
     type: string
@@ -37,9 +34,14 @@ parameters:
 jobs:
   build_kudet:
     docker:
-      - image: "goreleaser/goreleaser:<< pipeline.parameters.goreleaser-version >>"
+      - image: "cimg/go:<< pipeline.parameters.go-version >>"
     resource_class: large
     steps:
+      # Install goreleaser
+      - run: |
+          echo 'deb [trusted=yes] https://repo.goreleaser.com/apt/ /' | sudo tee /etc/apt/sources.list.d/goreleaser.list
+          sudo apt update
+          sudo apt install goreleaser
       - checkout
       # The 'git config' and 'go env' steps are to allow Go to read modules from our private Github repos
       # The KURTOSISBOT_GITHUB_TOKEN is a secret provided at CI build time
@@ -66,8 +68,13 @@ jobs:
             - "./<< pipeline.parameters.kudet-dist-home-relative-dirpath >>"
   push_kudet_artifacts:
     docker:
-      - image: "goreleaser/goreleaser:<< pipeline.parameters.goreleaser-version >>"
+      - image: "cimg/go:<< pipeline.parameters.go-version >>"
     steps:
+      # Install goreleaser
+      - run: |
+          echo 'deb [trusted=yes] https://repo.goreleaser.com/apt/ /' | sudo tee /etc/apt/sources.list.d/goreleaser.list
+          sudo apt update
+          sudo apt install goreleaser
       - checkout
       # The 'git config' and 'go env' steps are to allow Go to read modules from our private Github repos
       # The KURTOSISBOT_GITHUB_TOKEN is a secret provided at CI build time
@@ -84,7 +91,6 @@ workflows:
           filters:
             branches:
               ignore:
-                - develop
                 - master
       - build_kudet:
           context:
@@ -92,7 +98,6 @@ workflows:
           filters:
             branches:
               ignore:
-                - develop
                 - master
       - push_kudet_artifacts:
           context:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,17 @@
+# A wrapper workflow that calls down to Kurtosis Release workflow repo
+name: Release Workflow
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump_major:
+        description: 'Do you want to bump the MAJOR version ("X" in "X.Y.Z") on this release?'
+        required: true
+        type: boolean
+
+jobs:
+  release:
+    uses: kurtosis-tech/release/.github/workflows/release.yml@master
+    with:
+      bump_major: ${{ inputs.bump_major }}
+    secrets: inherit

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,7 @@
 # TBD
 
 * Add flag to bump major version for release command
+* Migrate repo to use new release workflow
 
 # 0.1.5
 * Require authentication through personal access token for release command


### PR DESCRIPTION
This PR makes the following changes to migrate this repo to the new release workflow outlined in [engineering-processes.md](https://github.com/kurtosis-tech/kurtosis-internal-docs/blob/master/engineering-processes.md) as of 07/07/2022:

- Adds github action for new release workflow to run
- Removes references to `develop` branch in CircleCI
- Adds a `.pre-release-scripts.txt`
