### PR TITLE
Fix get-docker-tag 

### DIFF
--- a/commands/get-docker-tag/get_docker_tag.go
+++ b/commands/get-docker-tag/get_docker_tag.go
@@ -15,14 +15,16 @@ import (
 )
 
 const (
-	gitDirname                 = ".git"
-	abbrevCommitLength         = 6
-	dirtySuffix                = "-dirty"
-	getDockerTagCmdStr         = "get-docker-tag"
-	invalidDockerCharsRegexStr = "[^a-zA-Z0-9]"
+	gitDirname         = ".git"
+	abbrevCommitLength = 6
+	dirtySuffix        = "-dirty"
+	getDockerTagCmdStr = "get-docker-tag"
+
+	// Rules on valid docker images: https://docs.docker.com/engine/reference/commandline/tag
+	invalidDockerImgCharsRegexStr = "[^a-zA-Z0-9._-]|^\\.|^-"
 )
 
-var invalidDockerCharsRegex = regexp.MustCompile(invalidDockerCharsRegexStr)
+var invalidDockerCharsRegex = regexp.MustCompile(invalidDockerImgCharsRegexStr)
 
 var GetDockerTagCmd = &cobra.Command{
 	Use:   getDockerTagCmdStr,

--- a/commands/get-docker-tag/get_docker_tag_test.go
+++ b/commands/get-docker-tag/get_docker_tag_test.go
@@ -1,0 +1,32 @@
+package getdockertag
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestInvalidDockerImgCharsRegex(t *testing.T) {
+	validStrings := []string{".1.55", "-1.553", "$docs", "^%$#", "branch/testing"}
+	invalidStrings := []string{"1.55.3", "branch-testing", "12340523", "12340523-dirty", "asdf", ""}
+
+	testRegexPattern(t, "Invalid Docker Image Characters Regex", invalidDockerImgCharsRegexStr, validStrings, invalidStrings)
+}
+
+// ====================================================================================================
+//                                       Private Helper Functions
+// ====================================================================================================
+func testRegexPattern(t *testing.T, regexPatternName string, regexPatternStr string, validStrings []string, invalidStrings []string) {
+	regexPattern := regexp.MustCompile(regexPatternStr)
+
+	for _, str := range validStrings {
+		patternDetected := regexPattern.Match([]byte(str))
+		require.True(t, patternDetected, "%s Pattern was not detected in this string when it should have been: '%s'.", regexPatternName, str)
+	}
+
+	for _, str := range invalidStrings {
+		patternDetected := regexPattern.Match([]byte(str))
+		require.False(t, patternDetected, "%s Pattern was detected in this string when it should not have been: '%s'.", regexPatternName, str)
+	}
+}

--- a/commands/get-docker-tag/get_docker_tag_test.go
+++ b/commands/get-docker-tag/get_docker_tag_test.go
@@ -22,11 +22,11 @@ func testRegexPattern(t *testing.T, regexPatternName string, regexPatternStr str
 
 	for _, str := range validStrings {
 		patternDetected := regexPattern.Match([]byte(str))
-		require.True(t, patternDetected, "%s Pattern was not detected in this string when it should have been: '%s'.", regexPatternName, str)
+		require.True(t, patternDetected, "'%s'Pattern was not detected in this string when it should have been: '%s'.", regexPatternName, str)
 	}
 
 	for _, str := range invalidStrings {
 		patternDetected := regexPattern.Match([]byte(str))
-		require.False(t, patternDetected, "%s Pattern was detected in this string when it should not have been: '%s'.", regexPatternName, str)
+		require.False(t, patternDetected, "'%s' Pattern was detected in this string when it should not have been: '%s'.", regexPatternName, str)
 	}
 }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,8 +1,11 @@
 # TBD
 
-# Changes
+### Changes
 * Migrate repo to use new release workflow
 * Merge `develop` into `master`
+
+### Fixes
+* Fix `invalidDockerImgCharsRegex` in `get-docker-tag`
 
 # 0.1.6
 * Add flag to bump major version for release command


### PR DESCRIPTION
Discovered a bug where `invalidDockerImgTagCharsRegex` was replacing `.` and `-` with `_` when it should not have been. 

According to official [docker tag](https://docs.docker.com/engine/reference/commandline/tag/#extended-description:%7E:text=A%20tag%20name%20must%20be,a%20maximum%20of%20128%20characters) docs, `.` and `-` are only invalid if they are at the start of the docker tag. 

Thus, fixed regex to follow desired functionality with unit tests.